### PR TITLE
Added support for CloudKey and instructions for automatic runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # unifi-acme.sh
 
-The `update-unifi-certificate.sh` script enables easy updating of the certificate used by [UniFi Controller](https://www.ubnt.com/enterprise/software). The script has been tested on Debian 8 "Jessie" with Unifi Controller installed via the official Debian repository.
+The `update-unifi-certificate.sh` script enables easy updating of the certificate used by [UniFi Controller](https://www.ubnt.com/enterprise/software). The script has been tested on Debian 8 "Jessie" with Unifi Controller installed via the official Debian repository and on a UniFi CloudKey on firmware version 0.7.3.
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,8 @@ The `update-unifi-certificate.sh` script enables easy updating of the certificat
 ## How to use
 
 * Install [acme.sh](https://github.com/Neilpang/acme.sh) and follow the instructions to create a certificate for the domain you want to use to access UniFi Controller.
-* Update the `update-unifi-certificate.sh` script:
-  * Set the `DOMAIN` variable to the domain for which you previously generated a certificate using `acme.sh`.
-  * Set the `ACME_SH` variable to the location of the `acme.sh` installation.
-* Execute `update-unifi-certificate.sh` to update Unifi Controller.
-
-## TODO
-
-The `update-unifi-certificate.sh` script should be run automatically whenever a new certificate is generated via `acme.sh`. For now, you must manually execute `update-unifi-certificate.sh`.
+* Set the reload command to the `update-unifi-certificate.sh` script:
+  * `--reloadcmd '/path/to/update-unifi-certificate.sh "certificate.domain.here" "/path/to/.acme.sh"'`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The `update-unifi-certificate.sh` script enables easy updating of the certificat
 
 * Install [acme.sh](https://github.com/Neilpang/acme.sh) and follow the instructions to create a certificate for the domain you want to use to access UniFi Controller.
 * Set the reload command to the `update-unifi-certificate.sh` script:
-  * `--reloadcmd '/path/to/update-unifi-certificate.sh "certificate.domain.here" "/path/to/.acme.sh"'`
+  * `--reloadcmd '/path/to/update-unifi-certificate.sh "certificate.domain.here" "/path/to/certificate/directory"'`
+* If acme.sh was installed in the default directory (`.acme.sh` in the user's home directory) and the certificate directory is under `.acme.sh` and is named for the domain inside of it, the second parameter can be omitted from the command:
+  * `--reloadcmd '/path/to/update-unifi-certificate.sh "certificate.domain.here"'`
 
 ## License
 

--- a/update-unifi-certificate.sh
+++ b/update-unifi-certificate.sh
@@ -14,18 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# USER CONFIGURATION BEGIN
-
 # The domain for which acme.sh generated/generates a certificate
 DOMAIN="$1"
 
 # The path to the acme.sh installation
 ACME_SH="$2"
 
-# USER CONFIGURATION END
-
+# Are we on a CloudKey?
 uname -a | grep CloudKey > /dev/null
 CLOUD_KEY="$?"
+
+# Find out what user we are
+CURRENT_USER=$(whoami)
 
 echo "Updating UniFi Controller certificate"
 
@@ -92,8 +92,8 @@ java -jar /usr/lib/unifi/lib/ace.jar import_cert \
 if [ $CLOUD_KEY -eq 0 ]; then
 	if [ ! -f /etc/ssl/private/cloudkey.key.backup ]; then
 		echo "* Setting permissions on certificate and key for initial setup..."
-		chown root:ssl-cert ${WORKDIR}/fullchain.cer
-		chown root:ssl-cert ${WORKDIR}/${DOMAIN}.key
+		chown ${CURRENT_USER}:ssl-cert ${WORKDIR}/fullchain.cer
+		chown ${CURRENT_USER}:ssl-cert ${WORKDIR}/${DOMAIN}.key
 
 		chmod 640 ${WORKDIR}/fullchain.cer
 		chmod 640 ${WORKDIR}/${DOMAIN}.key

--- a/update-unifi-certificate.sh
+++ b/update-unifi-certificate.sh
@@ -35,6 +35,9 @@ openssl pkcs12 -export -passout pass:aircontrolenterprise \
  -out ${WORKDIR}/keystore.pkcs12 -name unifi \
  -CAfile ${WORKDIR}/fullchain.cer -caname root
 
+echo "* Stopping nginx..."
+systemctl stop nginx
+
 echo "* Stopping UniFi controller..."
 systemctl stop unifi
 
@@ -74,3 +77,6 @@ java -jar /usr/lib/unifi/lib/ace.jar import_cert \
 
 echo "* Starting UniFi Controller..."
 systemctl start unifi
+
+echo "* Starting nginx..."
+systemctl start nginx


### PR DESCRIPTION
I have a CloudKey, so I added some detection for that along with some specific steps for initial setup on it and future certificate updates.  While I was at it, I also updated the readme to indicate how to run this script automatically after certificate updates.